### PR TITLE
Export the `CommandCollector` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ use crate::event::{EventReceiver, EventSender};
 use crate::model::Model;
 pub use crate::options::SkimOptions;
 pub use crate::output::SkimOutput;
+pub use crate::reader::CommandCollector;
 use crate::reader::Reader;
 
 #[cfg(feature = "malloc_trim")]


### PR DESCRIPTION
The `CommandCollector` trait being inaccessible means that users of the library can't provide their own `SkimItem`s in interactive mode.

(Motivation - I want to support interactive mode in my https://github.com/idanarye/nu_plugin_skim. It currently uses the original skim, but I'm PRing to here because this seems like the only actively maintained fork)